### PR TITLE
Api only works on the beta

### DIFF
--- a/api/usage.md
+++ b/api/usage.md
@@ -2,7 +2,7 @@
 
 ## Welcome
 
-Welcome to the Yacs API documentation!
+Welcome to the Yacs API documentation! Please note that currently this api only works on the beta for Yacs. Here is the link to the beta website for RPI if you would like to try it out [https://rpi.yacs.io/](https://rpi.yacs.io/) 
 
 The Yacs API fully implements [JSON-API v1](http://jsonapi.org/), a specification for creating RESTful APIs in JSON.
 It's basically GraphQL on JSON.


### PR DESCRIPTION
I added a message letting people know that for now the api only works on the beta website. I had tried to use it on the normal website with no luck and it was not so clear that currently it only works on the beta website if you are only reading the docs. I assume it will at some point get moved over to the main url in which case this message can probably be removed.